### PR TITLE
Fix service package initialization

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service utilities package."""


### PR DESCRIPTION
## Summary
- rename `src/services/__inti__.py` to `__init__.py`
- add module docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6876f221f36c8330aeef2f937c45ee9e