### PR TITLE
Fix supabase typo in TODO

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -24,7 +24,7 @@ class Container(containers.DeclarativeContainer):
 
     embeddings = providers.Singleton(OpenAIEmbeddings, model="text-embedding-3-small")
 
-    ## TODO: Milvus가 아닌 supabsae로 변경 필요요
+    ## TODO: Milvus가 아닌 supabase로 변경 필요요
     ## Vector DB 초기화 비활성화(Milvus 연동 비활성화)
     # vector_store_recap = providers.Singleton(
     #     Milvus,


### PR DESCRIPTION
## Summary
- correct spelling of `supabase` in startup TODO comment

## Testing
- `ruff check startup.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6876f7f5643c8330a091848a37102192