### PR TITLE
Add graph builder demo notebook

### DIFF
--- a/graph_builder_quick_test.ipynb
+++ b/graph_builder_quick_test.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Graph Builder Quick Test",
+    "이 노트북은 main.py에서 사용되는 노드 구성을 기반으로 그래프를 빠르게 빌드하고 테스트하기 위한 예제입니다."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from startup import Container",
+    "from src.graph.nodes import (",
+    "    NaverNewsSearcherNode,",
+    "    GoogleSearcherNode,",
+    "    RetrieveESGNode,",
+    "    ReportAssistantNode,",
+    "    ChosunRSSFeederNode,",
+    "    WSJEconomyRSSFeederNode,",
+    "    WSJMarketRSSFeederNode,",
+    "    CompanyFactsAnalyzerNode,",
+    "    USFinancialAnalyzerNode,",
+    ")",
+    "from src.graph.builder import SupervisorGraphBuilder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "container = Container()",
+    "graph_builder: SupervisorGraphBuilder = container.supervisor_graph()",
+    "",
+    "# main.py와 동일하게 노드를 등록합니다.",
+    "graph_builder.add_node(NaverNewsSearcherNode())",
+    "graph_builder.add_node(GoogleSearcherNode())",
+    "graph_builder.add_node(RetrieveESGNode())",
+    "graph_builder.add_node(ReportAssistantNode())",
+    "graph_builder.add_node(ChosunRSSFeederNode())",
+    "graph_builder.add_node(WSJEconomyRSSFeederNode())",
+    "graph_builder.add_node(WSJMarketRSSFeederNode())",
+    "graph_builder.add_node(CompanyFactsAnalyzerNode())",
+    "graph_builder.add_node(USFinancialAnalyzerNode())",
+    "",
+    "graph_builder.build()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, Image",
+    "",
+    "# mermaid 그래프 출력 (langgraph의 기능을 활용합니다)",
+    "display(Image(graph_builder._graph.get_graph().draw_mermaid_png()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# 그래프 실행 테스트",
+    "state = {",
+    "    \"messages\": [(\"human\", \"애플 최근 주가 소식 알려줘\")],",
+    "    \"llm\": container.llm()",
+    "}",
+    "result = graph_builder.execute(state)",
+    "print(result)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `graph_builder_quick_test.ipynb` for quick graph builds

## Testing
- `uvx ruff check --fix` *(fails: unsuccessful tunnel)*
- `uvx ruff format` *(fails: unsuccessful tunnel)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68787954c64483309f1c89c6350c914d